### PR TITLE
bugfix stack smashing regarding rawGrowth

### DIFF
--- a/source/mdcii/mdcii/include/mdcii/gam/gam_parser.hpp
+++ b/source/mdcii/mdcii/include/mdcii/gam/gam_parser.hpp
@@ -58,19 +58,19 @@ public:
 private:
   Files* files;
   std::vector<std::shared_ptr<Chunk>> chunks;
-  std::vector<std::shared_ptr<Island5>> islands5; // INSEL5
-  std::shared_ptr<Mission2> mission2;             // AUFTRAG2
-  std::shared_ptr<Mission4> mission4;             // AUFTRAG4
-  std::shared_ptr<SceneRanking> sceneRanking;     // SZENE_RANKING
-  std::shared_ptr<SceneSave> sceneSave;           // SZENE2
-  std::shared_ptr<Shipyard> shipyard;             // WERFT
-  std::shared_ptr<Military> military;             // MILITAR
-  std::shared_ptr<ProductionList> productionList; // PRODLIST2
-  std::shared_ptr<Warehouse2> warehouse;          // KONTOR2
-  std::shared_ptr<Settlers> settlers;             // SIEDLER
-  std::shared_ptr<MarketPlace> marketPlace;       // MARKT
-  std::shared_ptr<RawGrowth> rawGrowth;           // ROHWACHS2
-  std::shared_ptr<City4> city;                    // STADT4
+  std::vector<std::shared_ptr<Island5>> islands5;    // INSEL5
+  std::shared_ptr<Mission2> mission2;                // AUFTRAG2
+  std::shared_ptr<Mission4> mission4;                // AUFTRAG4
+  std::shared_ptr<SceneRanking> sceneRanking;        // SZENE_RANKING
+  std::shared_ptr<SceneSave> sceneSave;              // SZENE2
+  std::shared_ptr<Shipyard> shipyard;                // WERFT
+  std::shared_ptr<Military> military;                // MILITAR
+  std::shared_ptr<ProductionList> productionList;    // PRODLIST2
+  std::shared_ptr<Warehouse2> warehouse;             // KONTOR2
+  std::shared_ptr<Settlers> settlers;                // SIEDLER
+  std::shared_ptr<MarketPlace> marketPlace;          // MARKT
+  std::vector<std::shared_ptr<RawGrowth>> rawGrowth; // ROHWACHS2
+  std::shared_ptr<City4> city;                       // STADT4
 };
 
 #endif // _GAM_PARSER_HPP

--- a/source/mdcii/mdcii/include/mdcii/gam/rawgrowth.hpp
+++ b/source/mdcii/mdcii/include/mdcii/gam/rawgrowth.hpp
@@ -30,6 +30,8 @@ struct RawGrowthData // ROHWACHS2
   uint8_t speed;          // Which speed counter (MAXWACHSSPEEDKIND)
   uint8_t speedcnt;       // If (Timecnt != SpeedCnt) currentfield->animationCount++ (MAXROHWACHSCNT)
   uint8_t animationCount; // current animation index
+  uint8_t empty1;
+  uint8_t empty2;
 };
 
 class RawGrowth

--- a/source/mdcii/mdcii/src/gam/gam_parser.cpp
+++ b/source/mdcii/mdcii/src/gam/gam_parser.cpp
@@ -127,7 +127,8 @@ GamParser::GamParser(const std::string& gam, bool peek)
       }
       else if (chunkName == "ROHWACHS2")
       {
-        rawGrowth = std::make_shared<RawGrowth>(chunks[chunkIndex]->chunk.data, chunks[chunkIndex]->chunk.length, chunkName);
+        auto r = std::make_shared<RawGrowth>(chunks[chunkIndex]->chunk.data, chunks[chunkIndex]->chunk.length, chunkName);
+        rawGrowth.push_back(r);
       }
       else if (chunkName == "STADT3" || chunkName == "STADT4")
       {
@@ -246,9 +247,9 @@ GamParser::GamParser(const std::string& gam, bool peek)
   {
     std::cout << "marketplace: " << marketPlace->marketPlace.size() << std::endl;
   }
-  if (rawGrowth)
+  if (rawGrowth.size())
   {
-    std::cout << "rawGrowth: " << rawGrowth->rawGrowth.size() << std::endl;
+    std::cout << "rawGrowth: " << rawGrowth.size() << std::endl;
   }
   if (city)
   {


### PR DESCRIPTION
fixes #81 

raw growth data struct was two bytes to small (expectd 8 bytes), validated via hex dump of scenario file). Put two empty bytes at the end of the data struct. They seem to be constant zero. 