### PR TITLE
[fix] text cod parsing for english versions

### DIFF
--- a/source/mdcii/mdcii/src/cod/text_cod.cpp
+++ b/source/mdcii/mdcii/src/cod/text_cod.cpp
@@ -93,7 +93,7 @@ void TextCod::Parse()
     for (auto& line : codTxt)
     {
         // find the begin of a new section and add a new group
-        if (IsSubstring(line, "[END]") || IsSubstring(line, "--------------------------------------------------"))
+        if (IsSubstring(line, "[END]") || IsSubstring(line, "---"))
         {
             continue;
         }
@@ -113,3 +113,4 @@ void TextCod::Parse()
         }
     }
 }
+


### PR DESCRIPTION
the english version uses non unified dash-lines.
sometimes 21 long, sometimes contains a stray whitespace. so i changed it to `if it contains "---"`, which should catch all cases...