### PR TITLE
Renamed make target 'test' to 'unittests'

### DIFF
--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -16,7 +16,6 @@ project("${META_PROJECT_NAME}-tests" C CXX)
 set_policy(CMP0054 NEW) # ENABLE  CMP0054: Only interpret if() arguments as variables or keywords when unquoted.
 set_policy(CMP0042 NEW) # ENABLE  CMP0042: MACOSX_RPATH is enabled by default.
 set_policy(CMP0063 NEW) # ENABLE  CMP0063: Honor visibility properties for all target types.
-#set_policy(CMP0037 OLD) # DISABLE CMP0037: Target names should not be reserved and should match a validity pattern.
 
 # Compiler settings and options
 
@@ -38,8 +37,8 @@ function(add_test_without_ctest target)
         return()
     endif()
     
-    add_dependencies(test ${target})
-    add_custom_command(TARGET test POST_BUILD 
+    add_dependencies(unittests ${target})
+    add_custom_command(TARGET unittests POST_BUILD 
         COMMAND $<TARGET_FILE:${target}> --gtest_output=xml:gtests-${target}.xml
     )
 
@@ -72,11 +71,11 @@ target_link_libraries(gmock-dev
 
 
 # 
-# Target 'test'
+# Target 'unittests'
 # 
 
-add_custom_target(test)
-set_target_properties(test PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+add_custom_target(unittests)
+set_target_properties(unittests PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
 
 
 # 


### PR DESCRIPTION
This enables building of unit tests, because cmake CMP0037 forbids usage of name 'test'